### PR TITLE
Atualizar o link de CDN do FontDev

### DIFF
--- a/fontdev/README.md
+++ b/fontdev/README.md
@@ -1,3 +1,3 @@
 # Versions
 
-- v1.0.0 - https://cdn.rawgit.com/leojaimesson/cdn/master/fontdev/v1.0.0/fontdev.min.css
+- v1.0.0 - https://rawcdn.githack.com/leojaimesson/cdn/7352c3f63771c50912a006ff7c78c8a76c7092bc/fontdev/v1.0.0/fontdev.min.css


### PR DESCRIPTION
O RawGit está se desligando, então atualizei, por hora, para um provedor provisório